### PR TITLE
Update for Elm 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # elm-bootstrapify
-Supports Bootstrap 3 and Elm 0.17
+Supports Bootstrap 3 and Elm 0.18
 ## Purpose
 Elm-bootstrapify aims to elminate bootstrap styling rendering errors using precise type safety techniques.
 ## Installation

--- a/elm-package.json
+++ b/elm-package.json
@@ -17,8 +17,8 @@
         "Bootstrap.Buttons"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.3 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Bootstrap/Forms.elm
+++ b/src/Bootstrap/Forms.elm
@@ -41,14 +41,14 @@ type FormAlignmentOption =
      ]
 -}
 form : FormAlignmentOption -> List (Attribute msg) -> List (Html msg) -> Html msg
-form formAlignmentOption attributes htmlList =
+form formAlignmentOption extraAttributes htmlList =
   let
     formAlignmentClass =
       case formAlignmentOption of
         FormDefault -> ""
         FormHorizontal -> "form-horizontal"
         FormInline -> "form-inline"
-    attributes = class formAlignmentClass :: attributes
+    attributes = class formAlignmentClass :: extraAttributes
   in
     Html.form attributes htmlList
 
@@ -93,9 +93,9 @@ formGroup formGroupOption htmlList =
      ]
 -}
 formLabel : List (Attribute msg) -> List (Html msg) -> Html msg
-formLabel attributes htmlList =
+formLabel extraAttributes htmlList =
   let
-    attributes = class "control-label" :: attributes
+    attributes = class "control-label" :: extraAttributes
   in
     label attributes htmlList
 
@@ -110,9 +110,9 @@ formLabel attributes htmlList =
      ]
 -}
 formInput : List (Attribute msg) -> List (Html msg) -> Html msg
-formInput attributes htmlList =
+formInput extraAttributes htmlList =
   let
-    attributes = class "form-control" :: attributes
+    attributes = class "form-control" :: extraAttributes
   in
     input attributes htmlList
 
@@ -127,9 +127,9 @@ formInput attributes htmlList =
      ]
 -}
 formTextArea : List (Attribute msg) -> List (Html msg) -> Html msg
-formTextArea attributes htmlList =
+formTextArea extraAttributes htmlList =
   let
-    attributes = class "form-control" :: attributes
+    attributes = class "form-control" :: extraAttributes
   in
     textarea attributes htmlList
 

--- a/src/Bootstrap/ListGroup.elm
+++ b/src/Bootstrap/ListGroup.elm
@@ -32,8 +32,8 @@ listGroup htmlList =
      ]
 -}
 listGroupItem : List (Attribute msg) -> List (Html msg) -> Html msg
-listGroupItem attributes htmlList =
-  let attributes = class "list-group-item" :: attributes
+listGroupItem extraAttributes htmlList =
+  let attributes = class "list-group-item" :: extraAttributes
   in
     a attributes htmlList
 

--- a/src/Bootstrap/Navbar.elm
+++ b/src/Bootstrap/Navbar.elm
@@ -41,7 +41,7 @@ type NavbarType =
     navbar DefaultNavbar [] []
 -}
 navbar : NavbarType ->  List (Attribute msg) -> List (Html msg) -> Html msg
-navbar navbarType attributes htmlList =
+navbar navbarType extraAttributes htmlList =
   let
     navbarTypeClass =
       case navbarType of
@@ -49,7 +49,7 @@ navbar navbarType attributes htmlList =
         InverseNavbar -> "navbar-inverse"
         FormNavbar -> "navbar-form"
     navbarClass = "navbar " ++ navbarTypeClass
-    attributes = class navbarClass :: attributes
+    attributes = class navbarClass :: extraAttributes
   in
     nav attributes htmlList
 
@@ -58,9 +58,9 @@ navbar navbarType attributes htmlList =
     navbarHeader [] []
 -}
 navbarHeader : List (Attribute msg) -> List (Html msg) -> Html msg
-navbarHeader attributes htmlList =
+navbarHeader extraAttributes htmlList =
   let
-    attributes = class "navbar-header" :: attributes
+    attributes = class "navbar-header" :: extraAttributes
   in
     div attributes htmlList
 
@@ -69,9 +69,9 @@ navbarHeader attributes htmlList =
     navbarBrand [] []
 -}
 navbarBrand : List (Attribute msg) -> List (Html msg) -> Html msg
-navbarBrand attributes htmlList =
+navbarBrand extraAttributes htmlList =
   let
-    attributes = class "navbar-brand" :: attributes
+    attributes = class "navbar-brand" :: extraAttributes
   in
     a attributes htmlList
 
@@ -92,9 +92,9 @@ navbarBrand attributes htmlList =
      ]
 -}
 navbarCollapse : List (Attribute msg) -> List (Html msg) -> Html msg
-navbarCollapse attributes htmlList =
+navbarCollapse extraAttributes htmlList =
   let
-    attributes = class "collapse navbar-collapse" :: attributes
+    attributes = class "collapse navbar-collapse" :: extraAttributes
   in
     div attributes htmlList
 
@@ -107,7 +107,7 @@ navbarHamburger : String -> Html msg
 navbarHamburger target =
   let
     dataTargetAttribute = attribute "data-target" target
-    attributes =  [ attribute "data-toggle" "collapse", class "navbar-toggle", dataTargetAttribute ] ++ attributes
+    attributes =  [ attribute "data-toggle" "collapse", class "navbar-toggle", dataTargetAttribute ]
   in
     button attributes
      [
@@ -146,7 +146,7 @@ type NavbarOptions =
      ]
 -}
 navbarList : NavbarOptions -> NavbarListAdjustment -> List (Attribute msg) -> List (Html msg) -> Html msg
-navbarList navbarOption navbarListAdjustment attributes htmlList =
+navbarList navbarOption navbarListAdjustment extraAttributes htmlList =
   let
     navbarListAdjustmentClass =
       case navbarListAdjustment of
@@ -164,7 +164,7 @@ navbarList navbarOption navbarListAdjustment attributes htmlList =
         NavbarTabs -> "navbar-tabs"
         NavbarPills pillsOption -> "nav-pills " ++ (getNavbarPillsOptionClass pillsOption)
     navbarClass = "nav " ++ (getNavbarOptionClass navbarOption) ++ " " ++ navbarListAdjustmentClass
-    attributes = class navbarClass :: attributes
+    attributes = class navbarClass :: extraAttributes
   in
     ul attributes htmlList
 

--- a/src/Bootstrap/Page.elm
+++ b/src/Bootstrap/Page.elm
@@ -28,9 +28,9 @@ import String
 automationTag : String -> String -> Attribute msg
 automationTag tag value =
   let
-    tag = "data-uia-" ++ tag
+    dataTag = "data-uia-" ++ tag
   in
-    attribute tag value
+    attribute dataTag value
 
 -- Page
 ----------------------------------------------------------------------------
@@ -40,9 +40,9 @@ automationTag tag value =
     pullRight [] []
 -}
 pullRight : List (Attribute msg) -> List (Html msg) -> Html msg
-pullRight attributes htmlList =
+pullRight extraAttributes htmlList =
   let
-    attributes = class "pull-right" :: attributes
+    attributes = class "pull-right" :: extraAttributes
   in
     div attributes htmlList
 
@@ -51,9 +51,9 @@ pullRight attributes htmlList =
     pageHeader [] []
 -}
 pageHeader : List (Attribute msg) -> List (Html msg) -> Html msg
-pageHeader attributes htmlList =
+pageHeader extraAttributes htmlList =
   let
-    attributes = class "page-header" :: attributes
+    attributes = class "page-header" :: extraAttributes
   in
     div attributes htmlList
 
@@ -62,9 +62,9 @@ pageHeader attributes htmlList =
     jumbotron [] []
 -}
 jumbotron : List (Attribute msg) -> List (Html msg) -> Html msg
-jumbotron attributes htmlList =
+jumbotron extraAttributes htmlList =
   let
-    attributes = class "jumbotron" :: attributes
+    attributes = class "jumbotron" :: extraAttributes
   in
     div attributes htmlList
 

--- a/src/Bootstrap/Panels.elm
+++ b/src/Bootstrap/Panels.elm
@@ -48,7 +48,7 @@ panelGroup htmlList =
     panel PrimaryPanel [] []
 -}
 panel : PanelType -> List (Attribute msg) -> List (Html msg) -> Html msg
-panel panelType attributes htmlList =
+panel panelType extraAttributes htmlList =
   let
     getPanelTypeClass panelType =
       case panelType of
@@ -61,7 +61,7 @@ panel panelType attributes htmlList =
   in
     let
       panelTypeClass = getPanelTypeClass panelType
-      attributes = class ("panel " ++ panelTypeClass) :: attributes
+      attributes = class ("panel " ++ panelTypeClass) :: extraAttributes
     in
       div attributes htmlList
 
@@ -81,7 +81,7 @@ type PanelHeadingTitleType =
     panelHeading PanelH3 [] []
 -}
 panelHeading : PanelHeadingTitleType -> List (Attribute msg) -> List (Html msg) -> Html msg
-panelHeading panelHeadingTitleType attributes htmlList =
+panelHeading panelHeadingTitleType extraAttributes extraHtmlList =
   let
     getPanelHeadingTitleHtml panelHeadingTitleType =
       case panelHeadingTitleType of
@@ -93,8 +93,8 @@ panelHeading panelHeadingTitleType attributes htmlList =
         PanelH5 content -> h5 [] [ text content ]
 
     panelHeadingTitleHtml = getPanelHeadingTitleHtml panelHeadingTitleType
-    attributes = class "panel-heading" :: attributes
-    htmlList = panelHeadingTitleHtml :: htmlList
+    attributes = class "panel-heading" :: extraAttributes
+    htmlList = panelHeadingTitleHtml :: extraHtmlList
   in
     div attributes htmlList
 
@@ -103,9 +103,9 @@ panelHeading panelHeadingTitleType attributes htmlList =
     panelBody [] []
 -}
 panelBody : List (Attribute msg) -> List (Html msg) -> Html msg
-panelBody attributes htmlList =
+panelBody extraAttributes htmlList =
   let
-    attributes = class "panel-body" :: attributes
+    attributes = class "panel-body" :: extraAttributes
   in
     div attributes htmlList
 

--- a/src/Bootstrap/Wells.elm
+++ b/src/Bootstrap/Wells.elm
@@ -30,14 +30,14 @@ type WellOption =
     well WellLarge [] []
 -}
 well : WellOption -> List (Attribute msg) -> List (Html msg) -> Html msg
-well wellOption attributes htmlList =
+well wellOption extraAttributes htmlList =
   let
     wellOptionClass =
       case wellOption of
         WellNormal -> ""
         WellSmall -> "well-sm"
         WellLarge -> "well-lg"
-    attributes = class ("well " ++ wellOptionClass) :: attributes
+    attributes = class ("well " ++ wellOptionClass) :: extraAttributes
   in
     div attributes htmlList
 


### PR DESCRIPTION
Great package, this has been a really convenient way to use Bootstrap with type safety!

When upgrading to Elm 0.18 I noticed some compiler errors from how Elm now guards against recursive values. This just renames some parameters to avoid the issue. The only thing I wasn't sure what to do with was https://github.com/JeremyBellows/elm-bootstrapify/blob/5ac98659720114093ac33edac8e6332021001a81/src/Bootstrap/Navbar.elm#L110. I'm new to Elm couldn't figure out where the `attributes` being appended at the end was coming from, so I don't know if removing it this way is an issue.