### PR TITLE
Upgrade to Elm 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # elm-bootstrapify
-Supports Bootstrap 3 and Elm 0.17-0.18
+Supports Bootstrap 3 and Elm 0.19
 ## Purpose
 Elm-bootstrapify aims to elminate bootstrap styling rendering errors using precise type safety techniques.
 ## Installation

--- a/elm.json
+++ b/elm.json
@@ -1,11 +1,9 @@
 {
-    "version": "9.0.0",
+    "type": "package",
+    "name": "JeremyBellows/elm-bootstrapify",
     "summary": "A collection of functions to use the bootstrap theme when designing html",
-    "repository": "https://github.com/JeremyBellows/elm-bootstrapify.git",
-    "license": "BSD3",
-    "source-directories": [
-        "./src"
-    ],
+    "license": "BSD-3-Clause",
+    "version": "9.0.0",
     "exposed-modules": [
         "Bootstrap.Grid",
         "Bootstrap.Panels",
@@ -16,9 +14,10 @@
         "Bootstrap.Wells",
         "Bootstrap.Buttons"
     ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm-lang/core": "4.0.3 <= v < 6.0.0",
-        "elm-lang/html": "1.1.0 <= v < 3.0.0"
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.19.0"
+    "test-dependencies": {}
 }

--- a/src/Bootstrap/Buttons.elm
+++ b/src/Bootstrap/Buttons.elm
@@ -1,14 +1,10 @@
-module Bootstrap.Buttons exposing
-  (
-   ButtonOption(BtnDefault, BtnPrimary, BtnSuccess, BtnWarning, BtnInfo, BtnDanger, BtnLink),
-   ButtonSizeModifier(BtnLarge, BtnBlock, BtnSmall, BtnExtraSmall, NavbarBtn ),
-   ButtonModifier(BtnCollapse),
-   btn
-  )
+module Bootstrap.Buttons exposing (ButtonOption(..), ButtonSizeModifier(..), ButtonModifier(..), btn)
 
 {-| Functions for bootstrap buttons
 
+
 # Buttons
+
 @docs ButtonOption, ButtonSizeModifier, ButtonModifier, btn
 
 -}
@@ -17,86 +13,124 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import String
 
+
+
 --Buttons
 ----------------------------------------------------------------------------
 
-{-|
-  A set of options for rendering a btn
--}
-type ButtonOption =
-    BtnDefault
-  | BtnPrimary
-  | BtnSuccess
-  | BtnWarning
-  | BtnInfo
-  | BtnDanger
-  | BtnLink
 
-{-|
-  A set of sizes for rendering a btn
+{-| A set of options for rendering a btn
 -}
-type ButtonSizeModifier =
-    BtnLarge
-  | BtnBlock
-  | BtnSmall
-  | BtnExtraSmall
-  | NavbarBtn
+type ButtonOption
+    = BtnDefault
+    | BtnPrimary
+    | BtnSuccess
+    | BtnWarning
+    | BtnInfo
+    | BtnDanger
+    | BtnLink
 
-{-|
-  Modifiers for button attributes
+
+{-| A set of sizes for rendering a btn
 -}
-type ButtonModifier =
-    BtnCollapse String
+type ButtonSizeModifier
+    = BtnLarge
+    | BtnBlock
+    | BtnSmall
+    | BtnExtraSmall
+    | NavbarBtn
+
+
+{-| Modifiers for button attributes
+-}
+type ButtonModifier
+    = BtnCollapse String
+
 
 getButtonModifierClass btnModifier =
-  case btnModifier of
-    BtnLarge -> "btn-lg"
-    BtnBlock -> "btn-block"
-    BtnSmall -> "btn-sm"
-    BtnExtraSmall -> "btn-xs"
-    NavbarBtn -> "navbar-btn"
+    case btnModifier of
+        BtnLarge ->
+            "btn-lg"
+
+        BtnBlock ->
+            "btn-block"
+
+        BtnSmall ->
+            "btn-sm"
+
+        BtnExtraSmall ->
+            "btn-xs"
+
+        NavbarBtn ->
+            "navbar-btn"
+
 
 getButtonModifierAttribute btnModifier =
-  case btnModifier of
-    BtnCollapse target -> [ attribute "data-toggle" "collapse", attribute "data-target" target ]
+    case btnModifier of
+        BtnCollapse target ->
+            [ attribute "data-toggle" "collapse", attribute "data-target" target ]
+
 
 {-| Generates a button html element
 
     btn BtnPrimary [ BtnBlock, BtnLarge ] [ BtnCollapse "#idOfElement, .orClass" ] [] [ text "Hello world!" ]
+
 -}
 btn : ButtonOption -> List ButtonSizeModifier -> List ButtonModifier -> List (Attribute msg) -> List (Html msg) -> Html msg
 btn btnOption btnSizeModifiers btnModifiers attributes htmlList =
-  let
-    buttonModifierClasses =
-     btnSizeModifiers
-     |> List.map getButtonModifierClass
-     |> List.map (\class -> class ++ " ")
-     |> String.concat
-    -----------------------------------------------------------------------
-    buttonModifierAttributes =
-     btnModifiers
-     |> List.map getButtonModifierAttribute
-     |> List.concat
-    -----------------------------------------------------------------------
-    buttonOptionClass =
-      case btnOption of
-        BtnDefault -> "btn-default"
-        BtnPrimary -> "btn-primary"
-        BtnSuccess -> "btn-success"
-        BtnInfo -> "btn-info"
-        BtnDanger -> "btn-danger"
-        BtnWarning -> "btn-warning"
-        BtnLink -> "btn-link"
-    -----------------------------------------------------------------------
-    classes =
-     "btn " ++ buttonOptionClass ++ " " ++ buttonModifierClasses
-    -----------------------------------------------------------------------
-    btnModifierAttributes =
-      buttonModifierAttributes ++ attributes
-    -----------------------------------------------------------------------
-    newAttributes = class classes :: btnModifierAttributes
-    -----------------------------------------------------------------------
-  in
+    let
+        buttonModifierClasses =
+            btnSizeModifiers
+                |> List.map getButtonModifierClass
+                |> List.map (\class -> class ++ " ")
+                |> String.concat
+
+        -----------------------------------------------------------------------
+        buttonModifierAttributes =
+            btnModifiers
+                |> List.map getButtonModifierAttribute
+                |> List.concat
+
+        -----------------------------------------------------------------------
+        buttonOptionClass =
+            case btnOption of
+                BtnDefault ->
+                    "btn-default"
+
+                BtnPrimary ->
+                    "btn-primary"
+
+                BtnSuccess ->
+                    "btn-success"
+
+                BtnInfo ->
+                    "btn-info"
+
+                BtnDanger ->
+                    "btn-danger"
+
+                BtnWarning ->
+                    "btn-warning"
+
+                BtnLink ->
+                    "btn-link"
+
+        -----------------------------------------------------------------------
+        classes =
+            "btn " ++ buttonOptionClass ++ " " ++ buttonModifierClasses
+
+        -----------------------------------------------------------------------
+        btnModifierAttributes =
+            buttonModifierAttributes ++ attributes
+
+        -----------------------------------------------------------------------
+        newAttributes =
+            class classes :: btnModifierAttributes
+
+        -----------------------------------------------------------------------
+    in
     button newAttributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Forms.elm
+++ b/src/Bootstrap/Forms.elm
@@ -1,17 +1,10 @@
-module Bootstrap.Forms exposing
-  (
-   FormAlignmentOption(FormDefault, FormHorizontal, FormInline),
-   form,
-   formGroup,
-   FormGroupOption(FormGroupDefault, FormGroupSmall, FormGroupLarge),
-   formLabel,
-   formInput,
-   formTextArea
-  )
+module Bootstrap.Forms exposing (FormAlignmentOption(..), form, formGroup, FormGroupOption(..), formLabel, formInput, formTextArea)
 
 {-| Bootstrap functions pertaining to forms
 
+
 # Forms
+
 @docs FormAlignmentOption, form, formGroup, FormGroupOption, formLabel, formInput, formTextArea
 
 -}
@@ -19,118 +12,151 @@ module Bootstrap.Forms exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 -- Forms
 ----------------------------------------------------------------------------
+
 
 {-| Options for Form Alignment
 
     case formAlignmentOption of
-      FormDefault -> ""
-      FormHorizontal -> "form-horizontal"
-      FormInline -> "form-inline"
+        FormDefault ->
+            ""
+
+        FormHorizontal ->
+            "form-horizontal"
+
+        FormInline ->
+            "form-inline"
+
 -}
-type FormAlignmentOption =
-    FormDefault
-  | FormHorizontal
-  | FormInline
+type FormAlignmentOption
+    = FormDefault
+    | FormHorizontal
+    | FormInline
+
 
 {-| Generates a form with the supplied alignment
 
-    form FormDefault [ onSubmit SomeMsg ]
-     [
-     ]
+    form FormDefault
+        [ onSubmit SomeMsg ]
+        []
+
 -}
 form : FormAlignmentOption -> List (Attribute msg) -> List (Html msg) -> Html msg
 form formAlignmentOption extraAttributes htmlList =
-  let
-    formAlignmentClass =
-      case formAlignmentOption of
-        FormDefault -> ""
-        FormHorizontal -> "form-horizontal"
-        FormInline -> "form-inline"
-    attributes = class formAlignmentClass :: extraAttributes
-  in
+    let
+        formAlignmentClass =
+            case formAlignmentOption of
+                FormDefault ->
+                    ""
+
+                FormHorizontal ->
+                    "form-horizontal"
+
+                FormInline ->
+                    "form-inline"
+
+        attributes =
+            class formAlignmentClass :: extraAttributes
+    in
     Html.form attributes htmlList
 
-{-|
-  A set of different Form group options
+
+{-| A set of different Form group options
 -}
-type FormGroupOption =
-    FormGroupDefault
-  | FormGroupSmall
-  | FormGroupLarge
+type FormGroupOption
+    = FormGroupDefault
+    | FormGroupSmall
+    | FormGroupLarge
+
 
 {-| Generates a formGroup html element
 
-    form FormDefault [ onSubmit SomeMsg ]
-     [
-      formGroup FormGroupDefault
-        [
+    form FormDefault
+        [ onSubmit SomeMsg ]
+        [ formGroup FormGroupDefault
+            []
         ]
-     ]
+
 -}
 formGroup : FormGroupOption -> List (Html msg) -> Html msg
 formGroup formGroupOption htmlList =
-  let
-    formGroupOptionClass =
-      case formGroupOption of
-        FormGroupDefault -> ""
-        FormGroupSmall -> "form-group-sm"
-        FormGroupLarge -> "form-group-lg"
-    formGroupClass =
-      "form-group " ++ formGroupOptionClass
-  in
+    let
+        formGroupOptionClass =
+            case formGroupOption of
+                FormGroupDefault ->
+                    ""
+
+                FormGroupSmall ->
+                    "form-group-sm"
+
+                FormGroupLarge ->
+                    "form-group-lg"
+
+        formGroupClass =
+            "form-group " ++ formGroupOptionClass
+    in
     div [ class formGroupClass ] htmlList
+
 
 {-| Generates a formLabel html element
 
-    form FormDefault [ onSubmit SomeMsg ]
-     [
-      formGroup FormGroupDefault
-        [
-         formLabel [] []
+    form FormDefault
+        [ onSubmit SomeMsg ]
+        [ formGroup FormGroupDefault
+            [ formLabel [] []
+            ]
         ]
-     ]
+
 -}
 formLabel : List (Attribute msg) -> List (Html msg) -> Html msg
 formLabel extraAttributes htmlList =
-  let
-    attributes = class "control-label" :: extraAttributes
-  in
+    let
+        attributes =
+            class "control-label" :: extraAttributes
+    in
     label attributes htmlList
+
 
 {-| Generates a formInput html element
 
-    form FormDefault [ onSubmit SomeMsg ]
-     [
-      formGroup FormGroupDefault
-        [
-         formInput [] []
+    form FormDefault
+        [ onSubmit SomeMsg ]
+        [ formGroup FormGroupDefault
+            [ formInput [] []
+            ]
         ]
-     ]
+
 -}
 formInput : List (Attribute msg) -> List (Html msg) -> Html msg
 formInput extraAttributes htmlList =
-  let
-    attributes = class "form-control" :: extraAttributes
-  in
+    let
+        attributes =
+            class "form-control" :: extraAttributes
+    in
     input attributes htmlList
+
 
 {-| Generates a form text area html element
 
-    form FormDefault [ onSubmit SomeMsg ]
-     [
-      formGroup FormGroupDefault
-        [
-         formTextArea [] []
+    form FormDefault
+        [ onSubmit SomeMsg ]
+        [ formGroup FormGroupDefault
+            [ formTextArea [] []
+            ]
         ]
-     ]
+
 -}
 formTextArea : List (Attribute msg) -> List (Html msg) -> Html msg
 formTextArea extraAttributes htmlList =
-  let
-    attributes = class "form-control" :: extraAttributes
-  in
+    let
+        attributes =
+            class "form-control" :: extraAttributes
+    in
     textarea attributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Grid.elm
+++ b/src/Bootstrap/Grid.elm
@@ -1,16 +1,18 @@
 module Bootstrap.Grid exposing
- (
-  containerFluid, container, row, column,
-  ColumnSize(One,Two,Three,Four,Five,Six,Seven,Eight,Nine,Ten,Eleven,Twelve),
-  ColumnType(ExtraSmall,Small,Medium,Large)
- )
+    ( containerFluid, container, row, column
+    , ColumnSize(..), ColumnType(..)
+    )
 
 {-| Bootstrap grid functions for generating html
 
+
 # Grid
+
 @docs containerFluid, container, row, column
 
+
 # Column
+
 @docs ColumnSize, ColumnType, column
 
 -}
@@ -18,116 +20,151 @@ module Bootstrap.Grid exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 --Grid
 ----------------------------------------------------------------------------
+
+
 {-| Generates a fluid container html element
 
-    containerFluid [ ]
+    containerFluid []
+
 -}
 containerFluid : List (Html msg) -> Html msg
 containerFluid htmlList =
-  div [ class "container-fluid" ] htmlList
+    div [ class "container-fluid" ] htmlList
+
 
 {-| Generates a container html element
 
-    container [ ]
+    container []
+
 -}
 container : List (Html msg) -> Html msg
 container htmlList =
-  div [ class "container" ] htmlList
+    div [ class "container" ] htmlList
+
 
 {-| Generates a row html element
 
     containerFluid
-     [
-      row
-       [
-       ]
-     ]
+        [ row
+            []
+        ]
+
 -}
 row : List (Html msg) -> Html msg
 row htmlList =
-  div [ class "row" ] htmlList
+    div [ class "row" ] htmlList
+
 
 {-| Type to be used when determining column size
-  Note that a row can only container up to 12 column size units
+Note that a row can only container up to 12 column size units
 -}
-type ColumnSize =
-    One
-  | Two
-  | Three
-  | Four
-  | Five
-  | Six
-  | Seven
-  | Eight
-  | Nine
-  | Ten
-  | Eleven
-  | Twelve
+type ColumnSize
+    = One
+    | Two
+    | Three
+    | Four
+    | Five
+    | Six
+    | Seven
+    | Eight
+    | Nine
+    | Ten
+    | Eleven
+    | Twelve
 
-{-|
-  Type to be used when determining column size based on screen size
-  Extra small devices Phones (<768px)
-  Small devices Tablets (≥768px)
-  Medium devices Desktops (≥992px)
-  Large devices Desktops (≥1200px)
+
+{-| Type to be used when determining column size based on screen size
+Extra small devices Phones (<768px)
+Small devices Tablets (≥768px)
+Medium devices Desktops (≥992px)
+Large devices Desktops (≥1200px)
 -}
-type ColumnType =
-    ExtraSmall ColumnSize
-  | Small ColumnSize
-  | Medium ColumnSize
-  | Large ColumnSize
+type ColumnType
+    = ExtraSmall ColumnSize
+    | Small ColumnSize
+    | Medium ColumnSize
+    | Large ColumnSize
+
 
 {-| Generates a column html element
 
     containerFluid
-     [
-      row
-       [
-        column [ ExtraSmall Twelve, Small Twelve, Medium Twelve, Large Twelve ]
-         [
-         ]
-       ]
-     ]
+        [ row
+            [ column [ ExtraSmall Twelve, Small Twelve, Medium Twelve, Large Twelve ]
+                []
+            ]
+        ]
+
 -}
 column : List ColumnType -> List (Html msg) -> Html msg
 column columns htmlList =
-  let
-    getColumnSizeString columnSize =
-      case columnSize of
-        One -> "1"
-        Two -> "2"
-        Three -> "3"
-        Four -> "4"
-        Five -> "5"
-        Six -> "6"
-        Seven -> "7"
-        Eight -> "8"
-        Nine -> "9"
-        Ten -> "10"
-        Eleven -> "11"
-        Twelve -> "12"
+    let
+        getColumnSizeString columnSize =
+            case columnSize of
+                One ->
+                    "1"
 
-    getColumnString columnType =
-      case columnType of
-        ExtraSmall columnSize ->
-          "col-xs-" ++ (getColumnSizeString columnSize)
-        Small columnSize ->
-          "col-sm-" ++ (getColumnSizeString columnSize)
-        Medium columnSize ->
-          "col-md-" ++ (getColumnSizeString columnSize)
-        Large columnSize ->
-          "col-lg-" ++ (getColumnSizeString columnSize)
+                Two ->
+                    "2"
 
-    flattenColumnList columnOne columnTwo =
-      columnOne ++ " " ++ columnTwo
+                Three ->
+                    "3"
 
-    columnClasses =
-      columns
-      |> List.map getColumnString
-      |> List.foldr flattenColumnList ""
-  in
+                Four ->
+                    "4"
+
+                Five ->
+                    "5"
+
+                Six ->
+                    "6"
+
+                Seven ->
+                    "7"
+
+                Eight ->
+                    "8"
+
+                Nine ->
+                    "9"
+
+                Ten ->
+                    "10"
+
+                Eleven ->
+                    "11"
+
+                Twelve ->
+                    "12"
+
+        getColumnString columnType =
+            case columnType of
+                ExtraSmall columnSize ->
+                    "col-xs-" ++ getColumnSizeString columnSize
+
+                Small columnSize ->
+                    "col-sm-" ++ getColumnSizeString columnSize
+
+                Medium columnSize ->
+                    "col-md-" ++ getColumnSizeString columnSize
+
+                Large columnSize ->
+                    "col-lg-" ++ getColumnSizeString columnSize
+
+        flattenColumnList columnOne columnTwo =
+            columnOne ++ " " ++ columnTwo
+
+        columnClasses =
+            columns
+                |> List.map getColumnString
+                |> List.foldr flattenColumnList ""
+    in
     div [ class columnClasses ] htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/ListGroup.elm
+++ b/src/Bootstrap/ListGroup.elm
@@ -1,11 +1,10 @@
-module Bootstrap.ListGroup exposing
-  (
-   listGroup, listGroupItem
-  )
+module Bootstrap.ListGroup exposing (listGroup, listGroupItem)
 
 {-| Functions for generating List group html
 
+
 # List Group
+
 @docs listGroup, listGroupItem
 
 -}
@@ -13,28 +12,37 @@ module Bootstrap.ListGroup exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 --List group
 ----------------------------------------------------------------------------
+
 
 {-| Generates a list group html element
 
     listGroup [] []
+
 -}
 listGroup : List (Html msg) -> Html msg
 listGroup htmlList =
-  div [ class "list-group" ] htmlList
+    div [ class "list-group" ] htmlList
+
 
 {-| Generates a list group item html element
 
     listGroup []
-     [
-      listGroupItem [] []
-     ]
+        [ listGroupItem [] []
+        ]
+
 -}
 listGroupItem : List (Attribute msg) -> List (Html msg) -> Html msg
 listGroupItem extraAttributes htmlList =
-  let attributes = class "list-group-item" :: extraAttributes
-  in
+    let
+        attributes =
+            class "list-group-item" :: extraAttributes
+    in
     a attributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Navbar.elm
+++ b/src/Bootstrap/Navbar.elm
@@ -1,23 +1,18 @@
 module Bootstrap.Navbar exposing
-  (
-   NavbarType(DefaultNavbar, InverseNavbar, FormNavbar),
-   navbar,
-   navbarHeader,
-   navbarBrand,
-   navbarCollapse,
-   navbarHamburger,
-   NavbarListAdjustment(NavbarDefault,NavbarRight,NavbarLeft,NavbarJustified),
-   NavbarPillsOptions(PillsNotStacked, PillsStacked),
-   NavbarOptions(NavbarNav, NavbarTabs, NavbarPills),
-   navbarList
-  )
+    ( NavbarType(..), navbar, navbarHeader, navbarBrand, navbarCollapse, navbarHamburger
+    , NavbarListAdjustment(..), NavbarPillsOptions(..), NavbarOptions(..), navbarList
+    )
 
 {-| Functions for generating Bootstrap navbar elements
 
+
 # Navbar
+
 @docs NavbarType, navbar, navbarHeader, navbarBrand, navbarCollapse, navbarHamburger
 
+
 # Navbar List
+
 @docs NavbarListAdjustment, NavbarPillsOptions, NavbarOptions, navbarList
 
 -}
@@ -25,78 +20,99 @@ module Bootstrap.Navbar exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 --Navbar
 ----------------------------------------------------------------------------
 
-{-|
-  Different types of Navbar styles
+
+{-| Different types of Navbar styles
 -}
-type NavbarType =
-    DefaultNavbar
-  | InverseNavbar
-  | FormNavbar
+type NavbarType
+    = DefaultNavbar
+    | InverseNavbar
+    | FormNavbar
+
 
 {-| Generates a navbar html element
 
     navbar DefaultNavbar [] []
+
 -}
-navbar : NavbarType ->  List (Attribute msg) -> List (Html msg) -> Html msg
+navbar : NavbarType -> List (Attribute msg) -> List (Html msg) -> Html msg
 navbar navbarType extraAttributes htmlList =
-  let
-    navbarTypeClass =
-      case navbarType of
-        DefaultNavbar -> "navbar-default"
-        InverseNavbar -> "navbar-inverse"
-        FormNavbar -> "navbar-form"
-    navbarClass = "navbar " ++ navbarTypeClass
-    attributes = class navbarClass :: extraAttributes
-  in
+    let
+        navbarTypeClass =
+            case navbarType of
+                DefaultNavbar ->
+                    "navbar-default"
+
+                InverseNavbar ->
+                    "navbar-inverse"
+
+                FormNavbar ->
+                    "navbar-form"
+
+        navbarClass =
+            "navbar " ++ navbarTypeClass
+
+        attributes =
+            class navbarClass :: extraAttributes
+    in
     nav attributes htmlList
+
 
 {-| Generates a navbar header html element
 
     navbarHeader [] []
+
 -}
 navbarHeader : List (Attribute msg) -> List (Html msg) -> Html msg
 navbarHeader extraAttributes htmlList =
-  let
-    attributes = class "navbar-header" :: extraAttributes
-  in
+    let
+        attributes =
+            class "navbar-header" :: extraAttributes
+    in
     div attributes htmlList
+
 
 {-| Generates a navbarBrand html element
 
     navbarBrand [] []
+
 -}
 navbarBrand : List (Attribute msg) -> List (Html msg) -> Html msg
 navbarBrand extraAttributes htmlList =
-  let
-    attributes = class "navbar-brand" :: extraAttributes
-  in
+    let
+        attributes =
+            class "navbar-brand" :: extraAttributes
+    in
     a attributes htmlList
+
 
 {-| Generates a collapse div for navbar lists
 
     navbarCollapse [ id "collapseMe" ]
-     [
-      navbarList (NavbarPills PillsStacked) NavbarRight []
-       [
-        li []
-         [
-          a []
-           [
-            text "One"
-           ]
-         ]
-       ]
-     ]
+        [ navbarList (NavbarPills PillsStacked)
+            NavbarRight
+            []
+            [ li []
+                [ a []
+                    [ text "One"
+                    ]
+                ]
+            ]
+        ]
+
 -}
 navbarCollapse : List (Attribute msg) -> List (Html msg) -> Html msg
 navbarCollapse extraAttributes htmlList =
-  let
-    attributes = class "collapse navbar-collapse" :: extraAttributes
-  in
+    let
+        attributes =
+            class "collapse navbar-collapse" :: extraAttributes
+    in
     div attributes htmlList
+
 
 {-| Generates a collapse breadcrumb button for navbar lists. Parameter is for css selector depicting collapsable target
 
@@ -105,67 +121,96 @@ navbarCollapse extraAttributes htmlList =
 -}
 navbarHamburger : String -> Html msg
 navbarHamburger target =
-  let
-    dataTargetAttribute = attribute "data-target" target
-    attributes =  [ attribute "data-toggle" "collapse", class "navbar-toggle", dataTargetAttribute ]
-  in
+    let
+        dataTargetAttribute =
+            attribute "data-target" target
+
+        attributes =
+            [ attribute "data-toggle" "collapse", class "navbar-toggle", dataTargetAttribute ]
+    in
     button attributes
-     [
-      span [ class "icon-bar" ] [],
-      span [ class "icon-bar" ] [],
-      span [ class "icon-bar" ] []
-     ]
+        [ span [ class "icon-bar" ] []
+        , span [ class "icon-bar" ] []
+        , span [ class "icon-bar" ] []
+        ]
+
 
 {-| A set of options for adjusting a navbar list
 -}
-type NavbarListAdjustment =
-    NavbarDefault
-  | NavbarRight
-  | NavbarLeft
-  | NavbarJustified
+type NavbarListAdjustment
+    = NavbarDefault
+    | NavbarRight
+    | NavbarLeft
+    | NavbarJustified
 
-{-|
-  Option for Navbar Pills
--}
-type NavbarPillsOptions =
-    PillsNotStacked
-  | PillsStacked
 
-{-|
-  A set of Navbar Options
+{-| Option for Navbar Pills
 -}
-type NavbarOptions =
-    NavbarNav
-  | NavbarTabs
-  | NavbarPills NavbarPillsOptions
+type NavbarPillsOptions
+    = PillsNotStacked
+    | PillsStacked
+
+
+{-| A set of Navbar Options
+-}
+type NavbarOptions
+    = NavbarNav
+    | NavbarTabs
+    | NavbarPills NavbarPillsOptions
+
 
 {-| Generates a navbarList html element
 
-    navbarList (NavbarPills PillsStacked) NavbarRight []
-     [
-     ]
+    navbarList (NavbarPills PillsStacked)
+        NavbarRight
+        []
+        []
+
 -}
 navbarList : NavbarOptions -> NavbarListAdjustment -> List (Attribute msg) -> List (Html msg) -> Html msg
 navbarList navbarOption navbarListAdjustment extraAttributes htmlList =
-  let
-    navbarListAdjustmentClass =
-      case navbarListAdjustment of
-        NavbarDefault -> ""
-        NavbarLeft -> "navbar-left"
-        NavbarRight -> "navbar-right"
-        NavbarJustified -> "nav-justified"
-    getNavbarPillsOptionClass pillsOption =
-      case pillsOption of
-        PillsNotStacked -> ""
-        PillsStacked -> "nav-stacked"
-    getNavbarOptionClass navbarOption =
-      case navbarOption of
-        NavbarNav -> "navbar-nav"
-        NavbarTabs -> "navbar-tabs"
-        NavbarPills pillsOption -> "nav-pills " ++ (getNavbarPillsOptionClass pillsOption)
-    navbarClass = "nav " ++ (getNavbarOptionClass navbarOption) ++ " " ++ navbarListAdjustmentClass
-    attributes = class navbarClass :: extraAttributes
-  in
+    let
+        navbarListAdjustmentClass =
+            case navbarListAdjustment of
+                NavbarDefault ->
+                    ""
+
+                NavbarLeft ->
+                    "navbar-left"
+
+                NavbarRight ->
+                    "navbar-right"
+
+                NavbarJustified ->
+                    "nav-justified"
+
+        getNavbarPillsOptionClass pillsOption =
+            case pillsOption of
+                PillsNotStacked ->
+                    ""
+
+                PillsStacked ->
+                    "nav-stacked"
+
+        getNavbarOptionClass navbarOpt =
+            case navbarOpt of
+                NavbarNav ->
+                    "navbar-nav"
+
+                NavbarTabs ->
+                    "navbar-tabs"
+
+                NavbarPills pillsOption ->
+                    "nav-pills " ++ getNavbarPillsOptionClass pillsOption
+
+        navbarClass =
+            "nav " ++ getNavbarOptionClass navbarOption ++ " " ++ navbarListAdjustmentClass
+
+        attributes =
+            class navbarClass :: extraAttributes
+    in
     ul attributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Page.elm
+++ b/src/Bootstrap/Page.elm
@@ -1,71 +1,87 @@
 module Bootstrap.Page exposing
-  (
-   pullRight,
-   pageHeader,
-   jumbotron,
-   automationTag
-  )
+    ( pullRight, pageHeader, jumbotron
+    , automationTag
+    )
+
 {-| Bootstrap page functions
 
+
 # Page
+
 @docs pullRight, pageHeader, jumbotron
 
+
 # Automation
+
 @docs automationTag
 
 -}
 
-
 import Html exposing (..)
 import Html.Attributes exposing (..)
-
 import String
+
 
 {-| This is for being able to write UI Automation selectors efficiently
 
     button [ automationTag "btn" "submit" ] []
+
 -}
 automationTag : String -> String -> Attribute msg
 automationTag tag value =
-  let
-    dataTag = "data-uia-" ++ tag
-  in
+    let
+        dataTag =
+            "data-uia-" ++ tag
+    in
     attribute dataTag value
+
+
 
 -- Page
 ----------------------------------------------------------------------------
 
+
 {-| Generates a div with the pull-right class
 
     pullRight [] []
+
 -}
 pullRight : List (Attribute msg) -> List (Html msg) -> Html msg
 pullRight extraAttributes htmlList =
-  let
-    attributes = class "pull-right" :: extraAttributes
-  in
+    let
+        attributes =
+            class "pull-right" :: extraAttributes
+    in
     div attributes htmlList
+
 
 {-| Generates a page header html element
 
     pageHeader [] []
+
 -}
 pageHeader : List (Attribute msg) -> List (Html msg) -> Html msg
 pageHeader extraAttributes htmlList =
-  let
-    attributes = class "page-header" :: extraAttributes
-  in
+    let
+        attributes =
+            class "page-header" :: extraAttributes
+    in
     div attributes htmlList
+
 
 {-| Generates a jumbotron html element
 
     jumbotron [] []
+
 -}
 jumbotron : List (Attribute msg) -> List (Html msg) -> Html msg
 jumbotron extraAttributes htmlList =
-  let
-    attributes = class "jumbotron" :: extraAttributes
-  in
+    let
+        attributes =
+            class "jumbotron" :: extraAttributes
+    in
     div attributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Panels.elm
+++ b/src/Bootstrap/Panels.elm
@@ -1,19 +1,18 @@
 module Bootstrap.Panels exposing
-  (
-   PanelType(NormalPanel,PrimaryPanel,SuccessPanel,InfoPanel,WarningPanel,DangerPanel),
-   panelGroup,
-   panel,
-   panelHeading,
-   panelBody,
-   PanelHeadingTitleType(DefaultTitle,PanelH1,PanelH2,PanelH3,PanelH4,PanelH5)
-  )
+    ( PanelType(..), panelGroup, panel, panelHeading, panelBody
+    , PanelHeadingTitleType(..)
+    )
 
 {-| Functions for generating bootstrap panels
 
+
 # Panels
+
 @docs PanelType, panelGroup, panel, panelHeading, panelBody
 
+
 # Panel Headings
+
 @docs PanelHeadingTitleType, panelHeading
 
 -}
@@ -21,92 +20,135 @@ module Bootstrap.Panels exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 --Panels
 ----------------------------------------------------------------------------
 
-{-|
-  A set of options for Panels
+
+{-| A set of options for Panels
 -}
-type PanelType =
-    NormalPanel
-  | PrimaryPanel
-  | SuccessPanel
-  | InfoPanel
-  | WarningPanel
-  | DangerPanel
+type PanelType
+    = NormalPanel
+    | PrimaryPanel
+    | SuccessPanel
+    | InfoPanel
+    | WarningPanel
+    | DangerPanel
+
 
 {-| Generates a panelGroup html element
 
     panelGroup [] []
+
 -}
 panelGroup : List (Html msg) -> Html msg
 panelGroup htmlList =
-  div [ class "panel-group" ] htmlList
+    div [ class "panel-group" ] htmlList
+
 
 {-| Generates a panel html element
 
     panel PrimaryPanel [] []
+
 -}
 panel : PanelType -> List (Attribute msg) -> List (Html msg) -> Html msg
 panel panelType extraAttributes htmlList =
-  let
-    getPanelTypeClass panelType =
-      case panelType of
-        NormalPanel -> "panel-default"
-        PrimaryPanel -> "panel-primary"
-        SuccessPanel -> "panel-success"
-        InfoPanel -> "panel-info"
-        WarningPanel -> "panel-warning"
-        DangerPanel -> "panel-danger"
-  in
     let
-      panelTypeClass = getPanelTypeClass panelType
-      attributes = class ("panel " ++ panelTypeClass) :: extraAttributes
-    in
-      div attributes htmlList
+        getPanelTypeClass pt =
+            case pt of
+                NormalPanel ->
+                    "panel-default"
 
-{-|
-  Types of Panel Headings
+                PrimaryPanel ->
+                    "panel-primary"
+
+                SuccessPanel ->
+                    "panel-success"
+
+                InfoPanel ->
+                    "panel-info"
+
+                WarningPanel ->
+                    "panel-warning"
+
+                DangerPanel ->
+                    "panel-danger"
+    in
+    let
+        panelTypeClass =
+            getPanelTypeClass panelType
+
+        attributes =
+            class ("panel " ++ panelTypeClass) :: extraAttributes
+    in
+    div attributes htmlList
+
+
+{-| Types of Panel Headings
 -}
-type PanelHeadingTitleType =
-    DefaultTitle String
-  | PanelH1 String
-  | PanelH2 String
-  | PanelH3 String
-  | PanelH4 String
-  | PanelH5 String
+type PanelHeadingTitleType
+    = DefaultTitle String
+    | PanelH1 String
+    | PanelH2 String
+    | PanelH3 String
+    | PanelH4 String
+    | PanelH5 String
+
 
 {-| Generates a panelHeading html element
 
     panelHeading PanelH3 [] []
+
 -}
 panelHeading : PanelHeadingTitleType -> List (Attribute msg) -> List (Html msg) -> Html msg
 panelHeading panelHeadingTitleType extraAttributes extraHtmlList =
-  let
-    getPanelHeadingTitleHtml panelHeadingTitleType =
-      case panelHeadingTitleType of
-        DefaultTitle content -> text content
-        PanelH1 content -> h1 [] [ text content ]
-        PanelH2 content -> h2 [] [ text content ]
-        PanelH3 content -> h3 [] [ text content ]
-        PanelH4 content -> h4 [] [ text content ]
-        PanelH5 content -> h5 [] [ text content ]
+    let
+        getPanelHeadingTitleHtml titleType =
+            case titleType of
+                DefaultTitle content ->
+                    text content
 
-    panelHeadingTitleHtml = getPanelHeadingTitleHtml panelHeadingTitleType
-    attributes = class "panel-heading" :: extraAttributes
-    htmlList = panelHeadingTitleHtml :: extraHtmlList
-  in
+                PanelH1 content ->
+                    h1 [] [ text content ]
+
+                PanelH2 content ->
+                    h2 [] [ text content ]
+
+                PanelH3 content ->
+                    h3 [] [ text content ]
+
+                PanelH4 content ->
+                    h4 [] [ text content ]
+
+                PanelH5 content ->
+                    h5 [] [ text content ]
+
+        panelHeadingTitleHtml =
+            getPanelHeadingTitleHtml panelHeadingTitleType
+
+        attributes =
+            class "panel-heading" :: extraAttributes
+
+        htmlList =
+            panelHeadingTitleHtml :: extraHtmlList
+    in
     div attributes htmlList
+
 
 {-| Generates a panelBody html element
 
     panelBody [] []
+
 -}
 panelBody : List (Attribute msg) -> List (Html msg) -> Html msg
 panelBody extraAttributes htmlList =
-  let
-    attributes = class "panel-body" :: extraAttributes
-  in
+    let
+        attributes =
+            class "panel-body" :: extraAttributes
+    in
     div attributes htmlList
+
+
 
 ----------------------------------------------------------------------------

--- a/src/Bootstrap/Tables.elm
+++ b/src/Bootstrap/Tables.elm
@@ -1,75 +1,70 @@
-module Bootstrap.Tables exposing
-  (
-   TblOption(TableStriped, TableBordered, TableHover, TableCondensed),
-   tbl, tblResponsive
-  )
-
+module Bootstrap.Tables exposing (TblOption(..), tbl, tblResponsive)
 
 {-| Functions for bootstrap tables
 
+
 # Tables
+
 @docs TblOption, tbl, tblResponsive
 
 -}
-
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import String
 
 
-{-|
-  Options for the visual appearance
+{-| Options for the visual appearance
 -}
 type TblOption
-  = TableStriped
-  | TableBordered
-  | TableHover
-  | TableCondensed
+    = TableStriped
+    | TableBordered
+    | TableHover
+    | TableCondensed
 
 
 getTblOptionClass tblOption =
-  case tblOption of
-    TableStriped ->
-      "table-striped"
+    case tblOption of
+        TableStriped ->
+            "table-striped"
 
-    TableBordered ->
-      "table-bordered"
+        TableBordered ->
+            "table-bordered"
 
-    TableHover ->
-      "table-hover"
+        TableHover ->
+            "table-hover"
 
-    TableCondensed ->
-      "table-condensed"
+        TableCondensed ->
+            "table-condensed"
 
 
 {-| Generates a table html element
 
     tbl [ TableStriped, TableHover ] [] [ tableHead, tableBody ]
+
 -}
 tbl : List TblOption -> List (Attribute msg) -> List (Html msg) -> Html msg
 tbl tblOptions attributes htmlList =
-  let
-    tblOptionClasses =
-      tblOptions
-      |> List.map getTblOptionClass
-      |> List.map ((++) " ")
-      |> String.concat
+    let
+        tblOptionClasses =
+            tblOptions
+                |> List.map getTblOptionClass
+                |> List.map ((++) " ")
+                |> String.concat
 
-    classes =
-      "table" ++ tblOptionClasses
+        classes =
+            "table" ++ tblOptionClasses
 
-    newAttributes =
-      class classes :: attributes
-  in
+        newAttributes =
+            class classes :: attributes
+    in
     table newAttributes htmlList
 
 
-{-|
-  Wraps the table in a "table-responsive" div
+{-| Wraps the table in a "table-responsive" div
 -}
 tblResponsive : List TblOption -> List (Attribute msg) -> List (Html msg) -> Html msg
 tblResponsive tblOptions attributes htmlList =
-  div
-    [ class "table-responsive" ]
-    [ tbl tblOptions attributes htmlList ]
+    div
+        [ class "table-responsive" ]
+        [ tbl tblOptions attributes htmlList ]

--- a/src/Bootstrap/Wells.elm
+++ b/src/Bootstrap/Wells.elm
@@ -1,12 +1,10 @@
-module Bootstrap.Wells exposing
-  (
-   WellOption(WellNormal,WellSmall,WellLarge),
-   well
-  )
+module Bootstrap.Wells exposing (WellOption(..), well)
 
 {-| Functions for generating bootstrap wells
 
+
 # Wells
+
 @docs WellOption, well
 
 -}
@@ -14,31 +12,44 @@ module Bootstrap.Wells exposing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 
+
+
 --Well Well Well...  https://youtu.be/4iZOL63vej8?t=44
 ----------------------------------------------------------------------------
 
-{-|
-  Different Size Wells!
+
+{-| Different Size Wells!
 -}
-type WellOption =
-    WellNormal
-  | WellSmall
-  | WellLarge
+type WellOption
+    = WellNormal
+    | WellSmall
+    | WellLarge
+
 
 {-| Generates a well html element
 
     well WellLarge [] []
+
 -}
 well : WellOption -> List (Attribute msg) -> List (Html msg) -> Html msg
 well wellOption extraAttributes htmlList =
-  let
-    wellOptionClass =
-      case wellOption of
-        WellNormal -> ""
-        WellSmall -> "well-sm"
-        WellLarge -> "well-lg"
-    attributes = class ("well " ++ wellOptionClass) :: extraAttributes
-  in
+    let
+        wellOptionClass =
+            case wellOption of
+                WellNormal ->
+                    ""
+
+                WellSmall ->
+                    "well-sm"
+
+                WellLarge ->
+                    "well-lg"
+
+        attributes =
+            class ("well " ++ wellOptionClass) :: extraAttributes
+    in
     div attributes htmlList
+
+
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Most of this was done automatically with https://github.com/avh4/elm-upgrade. There were just a couple places with shadowing and duplicate exports that had to be manually updated to make the compiler happy.

I'm not sure backward compatibility with Elm 0.17-0.18 is possible due to the elm/core and elm/html package versions resetting to 1.0.0 with Elm 0.19.